### PR TITLE
Add Notifications centre and API gen

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 - Multiplayer games: Waku can be used to communicate game move off-chain, final state (e.g. winner) can then be submitted on chain for reward (e.g. NFT mint or winner takes stake).
 - IoT systems: Enable devices to communicate or report small data payload in a decentralized manner.
 - Decentralized wallet address ownership verification: Use Waku to enable communication between dApp and wallet such as signature or zeroknowledge proof exchange to prove identity.
+- Notifications centre: use an SDK (probably go-waku?) to build general Notification protocol over Waku and a mobile app allowing you to replace centralized Push Notifications provided by Apple/Google
+- API generator: build a tool to generate a Waku protocol (and code) from a provided OpenAPI specification 
 - Reputation systems:
 - Censorship resistant reviews plugin:
 - Privacy preserving location tracker:


### PR DESCRIPTION
Adding 2 more ideas:

* Notifications in mobile phones use centralized pubsub solutions, it would be great if a user could easily (and natively) hook into some kind of notification channel over Waku
* API generator - with OpenAPI spec you can define REST APIs - i.e. endpoints, accepted and returned payloads - and with some boilerplate code it should be possible to transform it into a request/response type of Waku app protocol